### PR TITLE
Update readysignal.R

### DIFF
--- a/R/readysignal.R
+++ b/R/readysignal.R
@@ -100,6 +100,14 @@ get_signal <- function(token, signal_id, infer_types = TRUE, optimized = NULL, s
   url <- httr::modify_url(url, query = query_params)
   sesh <- rvest::session(url, httr::add_headers(Authorization = auth))
 
+  # Check HTTP status before parsing JSON
+  if (sesh$response$status != 200) {
+    stop(sprintf(
+      "Connection to Ready Signal failed with status %d. Check that your access token is up-to-date and signal ID is valid.",
+      sesh$response$status
+    ))
+  }
+
   json <- jsonlite::fromJSON(
     httr::content(sesh$response, "text", encoding = "UTF8")
   )


### PR DESCRIPTION
Add HTTP status code validation in get_signal function

Added status code checking before JSON parsing to prevent errors when API returns non-200 responses (e.g., HTTP 405). Previously, the function would attempt to parse HTML error pages as JSON, causing cryptic errors.

- Check sesh$response$status before parsing JSON response (lines 103-109)
- Provide clear error message with status code when request fails
- Prevents "lexical error: invalid char in json text" errors

This improves error handling and makes debugging API issues easier.