### PR TITLE
Fix get_signal() coercing numeric columns to dates on R >= 4.3.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: readysignal
 Title: 'Ready Signal' API Wrapper
-Version: 0.0.10
+Version: 0.0.11
 Authors@R: 
     person(
         given = "Davis",

--- a/R/readysignal.R
+++ b/R/readysignal.R
@@ -155,18 +155,22 @@ get_signal <- function(token, signal_id, infer_types = TRUE, optimized = NULL, s
 
   if (infer_types) {
     for (i in seq_len(ncol(data))) {
-      tryCatch(
-        {
-          data[[i]] <- as.Date(data[[i]])
+      # Only character columns are date candidates. We must NOT attempt
+      # as.Date() on numeric/integer columns: as of R 4.3.0, as.Date.numeric()
+      # defaults `origin` to "1970-01-01" instead of erroring, so a value like
+      # 7 silently becomes "1970-01-08". That would turn every numeric metric
+      # into a bogus date.
+      if (is.character(data[[i]])) {
+        converted <- suppressWarnings(as.Date(data[[i]], format = "%Y-%m-%d"))
+        if (!all(is.na(converted))) {
+          data[[i]] <- converted
           next
-        },
-        warning = function(e) {},
-        error = function(e) {}
-      )
+        }
+      }
 
       tryCatch(
         {
-          data[[i]] <- type.convert(data[[i]])
+          data[[i]] <- type.convert(data[[i]], as.is = TRUE)
         },
         warning = function(e) {},
         error = function(e) {}


### PR DESCRIPTION
The infer_types loop tried as.Date() on every column first, relying on it to error for non-date columns and fall through to type.convert().

As of R 4.3.0, as.Date.numeric() no longer requires `origin` — it defaults to "1970-01-01" instead of erroring. So numeric/integer columns silently parsed as days-since-epoch: homes_sold 7 -> 1970-01-08, median_sale_price 157000 -> 2399-11-08. The raw API response and the UI download were always correct; only the R client's coercion was wrong.

Fix: gate as.Date() on is.character() and pass an explicit format = "%Y-%m-%d", so numeric columns are never reinterpreted as dates. Also set type.convert(as.is = TRUE) to keep geo fields as character. Bump version to 0.0.11.